### PR TITLE
Updates to handling binary/text data

### DIFF
--- a/kobo/pkgset.py
+++ b/kobo/pkgset.py
@@ -176,19 +176,21 @@ class SimpleRpmWrapper(FileWrapper):
         ts = kwargs.pop("ts", None)
         header = kobo.rpmlib.get_rpm_header(file_path, ts=ts)
 
-        self.name = kobo.rpmlib.get_header_field(header, "name")
-        self.version = kobo.rpmlib.get_header_field(header, "version")
-        self.release = kobo.rpmlib.get_header_field(header, "release")
+        self.name = kobo.rpmlib.get_header_field(header, "name").decode('utf-8')
+        self.version = kobo.rpmlib.get_header_field(header, "version").decode('utf-8')
+        self.release = kobo.rpmlib.get_header_field(header, "release").decode('utf-8')
         self.epoch = kobo.rpmlib.get_header_field(header, "epoch")
-        self.arch = kobo.rpmlib.get_header_field(header, "arch")
+        self.arch = kobo.rpmlib.get_header_field(header, "arch").decode('utf-8')
         self.signature = kobo.rpmlib.get_keys_from_header(header)
         if self.signature is not None:
             self.signature = self.signature.upper()
-        self.excludearch = kobo.rpmlib.get_header_field(header, "excludearch")
-        self.exclusivearch = kobo.rpmlib.get_header_field(header, "exclusivearch")
+        self.excludearch = [x.decode('utf-8') for x in kobo.rpmlib.get_header_field(header, "excludearch")]
+        self.exclusivearch = [x.decode('utf-8') for x in kobo.rpmlib.get_header_field(header, "exclusivearch")]
         self.sourcerpm = kobo.rpmlib.get_header_field(header, "sourcerpm")
+        if self.sourcerpm:
+            self.sourcerpm = self.sourcerpm.decode('utf-8')
         self.is_source = bool(kobo.rpmlib.get_header_field(header, "sourcepackage"))
-        self.is_system_release = "system-release" in kobo.rpmlib.get_header_field(header, "providename")
+        self.is_system_release = b"system-release" in kobo.rpmlib.get_header_field(header, "providename")
         self.checksum_type = kobo.rpmlib.get_digest_algo_from_header(header).lower()
 
     def __str__(self):

--- a/kobo/rpmlib.py
+++ b/kobo/rpmlib.py
@@ -92,15 +92,15 @@ def get_header_field(hdr, name):
     @param name: a rpm field name
     @type name: str
     @return: value of a rpm field
-    @rtype: str or list
+    @rtype: bytes or int or list
     """
 
     if name == "arch":
         # HACK: return "src" or "nosrc" arch instead of build arch
         if get_header_field(hdr, "sourcepackage"):
             if get_header_field(hdr, "nosource") or get_header_field(hdr, "nopatch"):
-                return "nosrc"
-            return "src"
+                return b"nosrc"
+            return b"src"
 
     hdr_key = getattr(rpm, "RPMTAG_%s" % name.upper(), None)
     if hdr_key is None:

--- a/kobo/shortcuts.py
+++ b/kobo/shortcuts.py
@@ -284,7 +284,9 @@ def run(cmd, show_cmd=False, stdout=False, logfile=None, can_fail=False, workdir
         # What happens to log file if it exists already? If show_cmd is True,
         # it will be overwritten. Otherwise the command output will just be
         # appended to the existing file.
-        mode = 'ab' if not show_cmd and os.path.exists(logfile) else 'wb'
+        mode = 'a' if not show_cmd and os.path.exists(logfile) else 'w'
+        if not kwargs.get('universal_newlines', False):
+            mode += 'b'
         log = open(logfile, mode)
 
     try:
@@ -316,7 +318,8 @@ def run(cmd, show_cmd=False, stdout=False, logfile=None, can_fail=False, workdir
             stdin_thread.daemon = True
             stdin_thread.start()
 
-        output = b""
+        output = "" if kwargs.get('universal_newlines', False) else b""
+        sentinel = "" if kwargs.get('universal_newlines', False) else b""
         while True:
             if buffer_size == -1:
                 lines = proc.stdout.readline()
@@ -330,7 +333,7 @@ def run(cmd, show_cmd=False, stdout=False, logfile=None, can_fail=False, workdir
                     else:
                         raise
 
-            if lines == b"":
+            if lines == sentinel:
                 break
             if stdout:
                 sys.stdout.write(lines)


### PR DESCRIPTION
The `get_header_field()` function is updated to always return `bytes` as the only stringish type. `SimpleRpmWrapper` is modified to decode all text fields into unicode/str.